### PR TITLE
Add conversational history to RAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ The app will be accessible from your browser using:
 ```bash
 https://{POD_ID}-{INTERNAL_PORT}.proxy.runpod.net
 ```
+
+### 🔄 Conversational History
+
+The assistant now keeps the history of questions and answers within the same
+session. This allows sending multiple sequential questions about the loaded
+document without losing previous context.


### PR DESCRIPTION
## Summary
- keep question/answer history in `ChatPDF`
- expose new behaviour in README

## Testing
- `python -m py_compile app.py backend.py chat.py helper.py rag.py`

------
https://chatgpt.com/codex/tasks/task_e_686286550284832985b9b2dad298cdd4