### PR TITLE
Handle multiple uploads in app

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,14 +23,19 @@ with st.sidebar:
 
 # Load and embed docs
 if uploaded_file:
+    files = uploaded_file if isinstance(uploaded_file, list) else [uploaded_file]
     if "qa_chain" not in st.session_state:
         with st.spinner("Processando documentos..."):
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_file:
-                tmp_file.write(uploaded_file.read())
-                tmp_file_path = tmp_file.name
+            all_docs = []
+            for _file in files:
+                with tempfile.NamedTemporaryFile(delete=False, suffix=".pdf") as tmp_file:
+                    tmp_file.write(_file.read())
+                    tmp_file_path = tmp_file.name
 
-            docs = process_pdf(tmp_file_path)
-            vectorstore = create_vectorstore(docs)
+                docs = process_pdf(tmp_file_path)
+                all_docs.extend(docs)
+
+            vectorstore = create_vectorstore(all_docs)
             st.session_state.qa_chain = build_qa_chain(vectorstore)
             st.session_state.conversation = []
 


### PR DESCRIPTION
## Summary
- support both single and multiple file uploads in `app.py`

## Testing
- `python -m py_compile app.py backend.py helper.py`


------
https://chatgpt.com/codex/tasks/task_e_6862961b9ed88329b514fd2a7ccbdee3