### PR TITLE
Fix reset button clearing history

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ def reset_chat():
         st.session_state["assistant"].clear()
     st.session_state["messages"] = []
     st.session_state["user_input"] = ""
+    if "conversation" in st.session_state:
+        st.session_state["conversation"] = []
 
 # Sidebar PDF upload
 with st.sidebar:


### PR DESCRIPTION
## Summary
- clear conversation list on reset

## Testing
- `python -m py_compile app.py chat.py rag.py backend.py helper.py app_backup.py`

------
https://chatgpt.com/codex/tasks/task_e_686299b7db6c8329bfc8b9a31c401bef